### PR TITLE
Avoid nullable struct for non-optional products

### DIFF
--- a/src/main/scala-3/io/github/pashashiz/spark_encoders/ProductEncoder.scala
+++ b/src/main/scala-3/io/github/pashashiz/spark_encoders/ProductEncoder.scala
@@ -62,8 +62,11 @@ class CaseClassEncoder[A: ClassTag](
       case (nameExpr, valueExpr) => nameExpr :: valueExpr :: Nil
     }
     val createExpr = CreateNamedStruct(exprs)
-    val nullExpr = Literal.create(null, createExpr.dataType)
-    If(IsNull(path), nullExpr, createExpr)
+    if (!nullable) createExpr
+    else {
+      val nullExpr = Literal.create(null, createExpr.dataType)
+      If(IsNull(path), nullExpr, createExpr)
+    }
   }
 
   override def fromCatalyst(path: Expression): Expression = {
@@ -81,8 +84,11 @@ class CaseClassEncoder[A: ClassTag](
       arguments = exprs,
       dataType = jvmRepr,
       propagateNull = true)
-    val nullExpr = Literal.create(null, jvmRepr)
-    If(IsNull(path), nullExpr, newExpr)
+    if (!nullable) AssertNotNull(newExpr)
+    else {
+      val nullExpr = Literal.create(null, jvmRepr)
+      If(IsNull(path), nullExpr, newExpr)
+    }
   }
 
   override def toString: String = s"CaseClassEncoder($jvmRepr)"

--- a/src/test/scala/io/github/pashashiz/spark_encoders/product/ProductExamples.scala
+++ b/src/test/scala/io/github/pashashiz/spark_encoders/product/ProductExamples.scala
@@ -1,0 +1,17 @@
+package io.github.pashashiz.spark_encoders.product
+
+import io.github.pashashiz.spark_encoders.{TypedEncoder, TypedEncoderImplicits}
+import java.sql.Timestamp
+
+case class User(id: Long, name: String)
+case class RawChange[T](
+    entity: T,
+    changeType: String,
+    commitVersion: Long,
+    commitTimestamp: Timestamp)
+
+object ProductExamples extends TypedEncoderImplicits {
+  implicit val userEncoder: TypedEncoder[User] = derive[User]
+  implicit def rawChangeEncoder[T: TypedEncoder]: TypedEncoder[RawChange[T]] =
+    derive[RawChange[T]]
+}


### PR DESCRIPTION
## Motivation
When encoding case classes:
- **Type (agnostic) schema** correctly marks non-optional products as **non-nullable**.
- **Serializer (expression) schema** incorrectly marked those nested struct fields as **nullable** because we always wrapped them in `If(IsNull(...), null, ...)`.

This mismatch:
- Confuses plan inspection (strict fields appear nullable).
- Adds dead branches in generated code.

Separately, `Option[...]` relied on inner encoders to short-circuit on nulls, which isn’t guaranteed for all inners (e.g., case objects).



## Summary of changes

### CaseClassEncoder (ProductEncoder) — strict by default
- Remove unconditional `If(IsNull(...), null, ...)` around **non-optional** product types.
- Serializer now emits `CreateNamedStruct(...)` directly.
- Deserializer now returns `AssertNotNull(NewInstance(...))`.
- For **truly optional products** (e.g., `Option[WholeCaseClass]`), keep the `If(IsNull(...), null, ...)` form.

**Effect:** non-optional product fields surface as `nullable = false` in the serializer schema, matching the type schema. Runtime behavior (fail on unexpected nulls) is unchanged.

### OptionEncoder — short-circuit at the boundary
```scala
// toCatalyst
If(IsNull(unwrapped), null, inner.toCatalyst(unwrapped))

// fromCatalyst
WrapOption(
  If(IsNull(path), null, inner.fromCatalyst(path)),
  inner.jvmRepr
)
```
**Effect:** `None ↔ null` is guaranteed without relying on inner encoders. Inners are only evaluated when a real value is present. Fixes subtle cases like `Option[CaseObject]`.




## Tests
Added fixtures for:
- `User`, `RawChange[User]`: `entity` is **non-nullable** in both schemas.
- `RawChange[Option[User]]`: `entity` is **nullable** in both schemas; `None` round-trips to `null` and back.
- Mirror assertions under Scala 2 and Scala 3 builds.



## Behavior before vs. after (key points)

### Non-optional product field (e.g., `entity: User`)
- **Before:** serializer schema said `nullable = true` (due to `If(IsNull..., null, ...)`); deserializer still failed at runtime on nulls via `AssertNotNull`.
- **After:** serializer schema says `nullable = false` (matches type schema). Runtime strictness unchanged: unexpected `null` still throws.

### Optional product field (e.g., `entity: Option[User]`)
- **Before:** depended on inner encoders to short-circuit; some inners (e.g., case objects) didn’t, causing inconsistencies.
- **After:** `OptionEncoder` short-circuits unconditionally; `None ↔ null` is guaranteed.

### Outer joins / null-producing plans
- Non-optional destinations still fail fast on nulls (as they should).
- Optional destinations still decode to `None`.



## Rationale & safety
- **Serializer/type schema alignment:** Removing the dead `If` for non-optional products makes the plan reflect the model: strict fields aren’t advertised as nullable.
- **Runtime correctness:** Deserializer continues to enforce non-nulls via `AssertNotNull`. Only dead branches are removed.
- **Option soundness:** Short-circuiting in `OptionEncoder` assigns responsibility cleanly and stops relying on inners.



## Performance
- **Micro-win:** one fewer conditional branch per strict product field in generated code.
- No extra work on hot paths.



## Backward compatibility
- No user-visible API changes.
- Runtime behavior for non-optional vs. optional fields is unchanged.
- **Only** the serializer schema’s `nullable` presentation changes for strict fields (now correctly `false`).